### PR TITLE
let private property easier to use

### DIFF
--- a/src/Epub.ts
+++ b/src/Epub.ts
@@ -23,9 +23,9 @@ export default class Epub {
   epubPackage: Package
   ocf: Ocf
 
-  private _readingOrderList: ReadingOrderItem[]
-  private _isFixedLayout: boolean
-  private _spreadMode: RENDITIONSPREAD | null = null
+  _readingOrderList: ReadingOrderItem[]
+  _isFixedLayout: boolean
+  _spreadMode: RENDITIONSPREAD | null = null
 
   constructor(ocf: Ocf, epubPackage: Package) {
     this.ocf = ocf


### PR DESCRIPTION
The purpose is to let react app could use Epub._readingOrderList from service worker json response.
Without making _readingOrderList Epub loaded from json response can not really access _readingOrderList because the function did not come with json response so the method readingOrderList() is useless in this case.